### PR TITLE
Mac addresses appear to be inverted

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Bridge Cync bluetooth mesh to mqtt. Includes auto-discovery for HomeAssistant.  Tested on Raspberry Pi3B+ and Pi-Zero-W
 This is an alpha quality WIP
 
+zimmra test version
+
 ## Features
 - Supports home assistant [MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/)
 - Supports mesh notifications (bulb status updates published to mqtt regardless of what set them).
@@ -15,7 +17,7 @@ python3 -mvenv ~/venv/cync2mqtt
 
 ### install into virtual environment
 ```shell
-~/venv/cync2mqtt/bin/pip3 install git+https://github.com/juanboro/cync2mqtt.git
+~/venv/cync2mqtt/bin/pip3 install git+https://github.com/zimmra/cync2mqtt.git
 ```
 
 ### Download Mesh Configuration from CYNC using 2FA

--- a/cync_mesh_example.yaml
+++ b/cync_mesh_example.yaml
@@ -1,0 +1,120 @@
+meshconfig:
+  1986531234:
+    access_key: 123456 #changed to 123456 for security, 6 digit number shown
+    bulbs:
+      1986531234001:
+        mac: A4C138542AB3
+        name: Kitchen Chandelier
+        supports_temperature: true
+      1986531234002:
+        mac: A4C1384CBE05
+        name: Kitchen Chandelier 2
+        supports_temperature: true
+      1986531234003:
+        mac: A4C1384C5DA1
+        name: Entry Chandelier
+        supports_temperature: true
+      1986531234004:
+        mac: A4C13865F6C6
+        name: Living Room 1
+        supports_temperature: true
+      1986531234005:
+        mac: A4C138696625
+        name: Living Room 4
+        supports_temperature: true
+      1986531234006:
+        mac: A4C13865F7B3
+        name: Living Room 3
+        supports_temperature: true
+      1986531234007:
+        mac: A4C1384EFE85
+        name: Kitchen Chandelier 3
+        supports_temperature: true
+      1986531234008:
+        mac: A4C13869C714
+        name: Living Room 2
+        supports_temperature: true
+      1986531234009:
+        mac: A4C1385389FD
+        name: Entry Chandelier 2
+        supports_temperature: true
+      1986531234010:
+        mac: A4C1384C7E0D
+        name: Kitchen Chandelier 4
+        supports_temperature: true
+      1986531234011:
+        mac: A4C1384CD8C8
+        name: Living Room Floor Lamp
+        supports_temperature: true
+      1986531234012:
+        mac: A4C1384B490A
+        name: Entry Chandelier 3
+        supports_temperature: true
+      1986531234013:
+        mac: A4C1384AE654
+        name: Kitchen Chandelier 5
+        supports_temperature: true
+      1986531234014:
+        mac: A4C1388162E8
+        name: Movie Room Floor Lamp
+      1986531234015:
+        mac: A4C138572C0A
+        name: Laundry Hall Light
+        supports_temperature: true
+      1986531234016:
+        mac: A4C13863C938
+        name: Hallway 4
+        supports_temperature: true
+      1986531234017:
+        mac: A4C13866382E
+        name: Hallway 1
+        supports_temperature: true
+      1986531234018:
+        mac: A4C1386CE2D2
+        name: Hallway 3
+        supports_temperature: true
+      1986531234019:
+        mac: A4C13863B8DA
+        name: Hallway 2
+        supports_temperature: true
+      1986531234020:
+        mac: A4C1382B07F7
+        name: Desk Lamp
+        supports_temperature: true
+      1986531234021:
+        mac: A4C138EAAD06
+        name: Bed Lamp 1
+      1986531234022:
+        mac: A4C138EAC218
+        name: Bed Lamp 2
+      1986531234023:
+        mac: A4C138EAB5F8
+        name: Floor Lamp 3
+      1986531234024:
+        mac: A4C1386CBCC4
+        name: Floor Lamp 2
+        supports_temperature: true
+      1986531234025:
+        mac: A4C138E92BDB
+        name: Floor Lamp 1
+      1986531234026:
+        mac: A4C138E94270
+        name: Vanity 2
+      1986531234027:
+        mac: A4C138E83FF1
+        name: Vanity 4
+      1986531234028:
+        mac: A4C138E91EEF
+        name: Vanity 6
+      1986531234029:
+        mac: A4C138E786A6
+        name: Vanity 3
+      1986531234030:
+        mac: A4C138E94F8E
+        name: Vanity 1
+      1986531234031:
+        mac: A4C138E763BC
+        name: Vanity 5
+    mac: 44ADB1815E67
+    name: HASS
+mqtt_url: mqtt://homeassistant:1883/

--- a/src/acync/__init__.py
+++ b/src/acync/__init__.py
@@ -94,7 +94,7 @@ class acync:
 
             newmesh['bulbs']={}
             for bulb in mesh['properties']['bulbsArray']:
-                id = int(bulb['deviceID'][-3:])
+                id = int(bulb['deviceID'])
                 bulbdevice=device(None,bulb['displayName'], id, bulb['mac'],bulb['deviceType'])
                 newbulb={}
                 for attrset in ('name','is_plug','supports_temperature','supports_rgb','mac'):

--- a/src/acync/__init__.py
+++ b/src/acync/__init__.py
@@ -94,7 +94,7 @@ class acync:
 
             newmesh['bulbs']={}
             for bulb in mesh['properties']['bulbsArray']:
-                id = int(bulb['deviceID'])
+                id = int(str(bulb['deviceID'])[-3:])
                 bulbdevice=device(None,bulb['displayName'], id, bulb['mac'],bulb['deviceType'])
                 newbulb={}
                 for attrset in ('name','is_plug','supports_temperature','supports_rgb','mac'):

--- a/src/acync/__init__.py
+++ b/src/acync/__init__.py
@@ -132,7 +132,7 @@ class acync:
             meshmacs={}
             for bulb in mesh['bulbs'].values():
                 mac = [bulb['mac'][i:i+2] for i in range(0, 12, 2)]
-                mac = "%s:%s:%s:%s:%s:%s" % (mac[5], mac[4], mac[3], mac[2], mac[1], mac[0])
+                mac = "%s:%s:%s:%s:%s:%s" % (mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
                 meshmacs[mac]=bulb['priority'] if 'priority' in bulb else 0
             
             #print(f"Add network: {mesh['name']}")
@@ -164,7 +164,7 @@ class acync:
             meshmacs=[]
             for bulb in mesh['properties']['bulbsArray']:
                 mac = [bulb['mac'][i:i+2] for i in range(0, 12, 2)]
-                mac = "%s:%s:%s:%s:%s:%s" % (mac[5], mac[4], mac[3], mac[2], mac[1], mac[0])
+                mac = "%s:%s:%s:%s:%s:%s" % (mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
                 meshmacs.append(mac)
 
             #print(f"Add network: {mesh['name']}")

--- a/src/acync/mesh.py
+++ b/src/acync/mesh.py
@@ -148,7 +148,7 @@ class atelink_mesh:
 
             self.currentmac=mac
             macarray = mac.split(':')
-            self.macdata = [int(macarray[5], 16), int(macarray[4], 16), int(macarray[3], 16), int(macarray[2], 16), int(macarray[1], 16), int(macarray[0], 16)]
+            self.macdata = [int(macarray[0], 16), int(macarray[1], 16), int(macarray[2], 16), int(macarray[3], 16), int(macarray[4], 16), int(macarray[5], 16)]
 
             data = [0] * 16
             random_data = get_random_bytes(8)


### PR DESCRIPTION
When attempting `~/venv/cync2mqtt/bin/cync2mqtt  ~/cync_mesh.yaml`, logs initially showed `Unable to connect to mesh mac: A1:5D:4C:38:C1:A4` (among other incorrect/inverted mac addresses)

Reordered the mac address arrays from 5 -> 0 to 0 -> 5
Not sure if these changes have unintended consequences, but now I successfully connect:
```
2021-12-14 20:52:43,288 - cync2mqtt - INFO - Connected to mesh mac: A4:C1:38:4C:BE:05
2021-12-14 20:52:43,289 - cync2mqtt - INFO - Connected to network(s): HASS
```

