### PR TITLE
Re-Order Mac Addresses

### DIFF
--- a/src/acync/__init__.py
+++ b/src/acync/__init__.py
@@ -132,7 +132,7 @@ class acync:
             meshmacs={}
             for bulb in mesh['bulbs'].values():
                 mac = [bulb['mac'][i:i+2] for i in range(0, 12, 2)]
-                mac = "%s:%s:%s:%s:%s:%s" % (mac[5], mac[4], mac[3], mac[2], mac[1], mac[0])
+                mac = "%s:%s:%s:%s:%s:%s" % (mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
                 meshmacs[mac]=bulb['priority'] if 'priority' in bulb else 0
             
             #print(f"Add network: {mesh['name']}")
@@ -164,7 +164,7 @@ class acync:
             meshmacs=[]
             for bulb in mesh['properties']['bulbsArray']:
                 mac = [bulb['mac'][i:i+2] for i in range(0, 12, 2)]
-                mac = "%s:%s:%s:%s:%s:%s" % (mac[5], mac[4], mac[3], mac[2], mac[1], mac[0])
+                mac = "%s:%s:%s:%s:%s:%s" % (mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
                 meshmacs.append(mac)
 
             #print(f"Add network: {mesh['name']}")

--- a/src/acync/mesh.py
+++ b/src/acync/mesh.py
@@ -148,7 +148,7 @@ class atelink_mesh:
 
             self.currentmac=mac
             macarray = mac.split(':')
-            self.macdata = [int(macarray[5], 16), int(macarray[4], 16), int(macarray[3], 16), int(macarray[2], 16), int(macarray[1], 16), int(macarray[0], 16)]
+            self.macdata = [int(macarray[0], 16), int(macarray[1], 16), int(macarray[2], 16), int(macarray[3], 16), int(macarray[4], 16), int(macarray[5], 16)]
 
             data = [0] * 16
             random_data = get_random_bytes(8)


### PR DESCRIPTION
Without this, when attempting `~/venv/cync2mqtt/bin/cync2mqtt  ~/cync_mesh.yaml`, logs initially showed `Unable to connect to mesh mac: A1:5D:4C:38:C1:A4` (among other incorrect/inverted mac addresses)

Reordered the mac address arrays from 5 -> 0 to 0 -> 5
**Not sure if these changes have unintended consequences**, but now I successfully connect:
```
2021-12-14 20:52:43,288 - cync2mqtt - INFO - Connected to mesh mac: A4:C1:38:4C:BE:05
2021-12-14 20:52:43,289 - cync2mqtt - INFO - Connected to network(s): HASS
```
