### PR TITLE
Add additional temp supported bulbs

### DIFF
--- a/src/acync/mesh.py
+++ b/src/acync/mesh.py
@@ -375,6 +375,8 @@ class device:
         if self._supports_temperature is not None: return self._supports_temperature
         if self.supports_rgb or \
            self.type == 5 or \
+           self.type == 10 or \
+           self.type == 11 or \
            self.type == 19 or \
            self.type == 20 or \
            self.type == 80 or \


### PR DESCRIPTION
Bulb types 10 (A19) and 11 (BR30) both support CCT/temperature attenuation