### PR TITLE
Change network.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sudo nano /etc/systemd/system/cync2mqtt.service
 ```ini 
 [Unit]
 Description=cync2mqtt
-After=network.target
+After=network-online.target
 
 [Service]
 ExecStart=/home/pi/venv/cync2mqtt/bin/cync2mqtt /home/pi/cync_mesh.yaml


### PR DESCRIPTION
Service wouldn't load successfully upon reboots, citing failed due to inability to connect to MQTT.

This now waits until the interface is 'up', instead of waiting until just the network stack was loaded.